### PR TITLE
Fixing trimming and block concatenation issues

### DIFF
--- a/EPS/New-EpsTemplateScript.ps1
+++ b/EPS/New-EpsTemplateScript.ps1
@@ -69,14 +69,14 @@ function New-EpsTemplateScript {
         }
         switch ($ind) {
             '=' {
-                Add-Expression $code
+                Add-Expression $code.Trim()
             }
             '-' {
                 Add-String ($content -replace '(?smi)([\n\r]+|\A)[ \t]+\z', '$1')
-                Add-Code $code
+                Add-Code $code.Trim()
             }
             '' {
-                Add-Code $code
+                Add-Code $code.Trim()
             }
             '%' {
                 Add-LiteralString "`$sb.Append('<%", $code, ">');"
@@ -87,6 +87,8 @@ function New-EpsTemplateScript {
         }
         if (($ind -ne '%') -and (($tail -ne '-') -or ($rspace -match '^[^\r\n]'))) {
             Add-String $rspace -NoEscape
+        } else {
+            Add-Code ";"
         }
     }
     if ($position -eq 0) {

--- a/EPS/New-EpsTemplateScript.ps1
+++ b/EPS/New-EpsTemplateScript.ps1
@@ -64,8 +64,10 @@ function New-EpsTemplateScript {
         $tail          = $Match.Groups["tailch"].Value
         $rspace        = $Match.Groups["rspace"].Value
 
-        if ($ind -ne '-') {
+        if (($ind -ne '-') -and ($content -ne "")) {
             Add-String $content
+        } else {
+            Add-Code ";"
         }
         switch ($ind) {
             '=' {

--- a/Tests/Invoke-EpsTemplate.Tests.ps1
+++ b/Tests/Invoke-EpsTemplate.Tests.ps1
@@ -145,6 +145,15 @@ function EpsTests {
 		It 'expands "<%# something -%>`na" to "a"' {
 			Invoke-EpsTemplate -Template "<%# something -%>`na" -Binding $Binding | Should Be "a"
 		}
+		It 'expands "<% $a = 5 %>`n<% if ($a) { } %>" to "`n"' {
+			# see issue #14
+			Invoke-EpsTemplate -Template "<% `$a = 5 %>`n<% if (`$a) { } %>" -Binding $Binding | Should Be "`n"
+		}		
+		It 'expands "<% $a = 5 -%>`n<% if ($a) { } %>" to "5"' {
+			# see issue #14
+			Invoke-EpsTemplate -Template "<% `$a = 5 -%>`n<% if (`$a) { } %>" -Binding $Binding | Should Be ""
+		}
+
 	}
 	Context 'with template "Hello <%= $A %>!" and with pipeline' {
 		$Template = 'Hello <%= $A %>!'

--- a/Tests/Invoke-EpsTemplate.Tests.ps1
+++ b/Tests/Invoke-EpsTemplate.Tests.ps1
@@ -149,11 +149,34 @@ function EpsTests {
 			# see issue #14
 			Invoke-EpsTemplate -Template "<% `$a = 5 %>`n<% if (`$a) { } %>" -Binding $Binding | Should Be "`n"
 		}		
-		It 'expands "<% $a = 5 -%>`n<% if ($a) { } %>" to "5"' {
+		It 'expands "<% $a = 5 -%>`n<% if ($a) { } %>" to ""' {
 			# see issue #14
 			Invoke-EpsTemplate -Template "<% `$a = 5 -%>`n<% if (`$a) { } %>" -Binding $Binding | Should Be ""
 		}
-
+		It 'expands "<% $a = 5 %><% $a.GetHashCode() %>" to ""' {
+			# see issue #14
+			Invoke-EpsTemplate -Template "<% `$a = 5 %><% `$a.GetHashCode() %>" -Binding $Binding | Should Be ""
+		}
+		It 'expands "<% $a = 5 %><%- $a.GetHashCode() %>" to ""' {
+			# see issue #14
+			Invoke-EpsTemplate -Template "<% `$a = 5 %><%- `$a.GetHashCode() %>" -Binding $Binding | Should Be ""
+		}
+		It 'expands "<% $a = 5 %>`n<%- $a.GetHashCode() %>" to "`n"' {
+			# see issue #14
+			Invoke-EpsTemplate -Template "<% `$a = 5 %>`n<%- `$a.GetHashCode() %>" -Binding $Binding | Should Be "`n"
+		}
+		It 'expands "<% $a = 5 %> <%- $a.GetHashCode() %>" to ""' {
+			# see issue #14
+			Invoke-EpsTemplate -Template "<% `$a = 5 %> <%- `$a.GetHashCode() %>" -Binding $Binding | Should Be ""
+		}
+		It 'expands "<% $a = 5 -%><%- $a.GetHashCode() %>" to ""' {
+			# see issue #14
+			Invoke-EpsTemplate -Template "<% `$a = 5 -%><%- `$a.GetHashCode() %>" -Binding $Binding | Should Be ""
+		}		
+		It 'expands "<% $a = 5 -%>`n<%- $a.GetHashCode() %>" to ""' {
+			# see issue #14
+			Invoke-EpsTemplate -Template "<% `$a = 5 -%>`n<%- `$a.GetHashCode() %>" -Binding $Binding | Should Be ""
+		}		
 	}
 	Context 'with template "Hello <%= $A %>!" and with pipeline' {
 		$Template = 'Hello <%= $A %>!'


### PR DESCRIPTION
Fixes #14 by inserting ";" at the right places when no space is inserted. Also, trimming code blocks to reduce the executable template size.