### PR TITLE
Added an 'Each' function for iteration joining

### DIFF
--- a/EPS/EPS.psd1
+++ b/EPS/EPS.psd1
@@ -5,7 +5,7 @@
 ModuleToProcess = 'EPS.psm1' # using ModuleToProcess for PS 2.0 compatibility
 
 # Version number of this module.
-ModuleVersion = '0.3.3'
+ModuleVersion = '0.4.0'
 
 # ID used to uniquely identify this module
 GUID = 'f24c1ca7-e4fd-4b7d-8ff8-75ef7f7ea162'
@@ -18,13 +18,8 @@ Copyright = '(c) 2014 Dave Wu. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = @'
-EPS (Embedded PowerShell), inspired by ERB (see https://en.wikipedia.org/wiki/ERuby), is a 
-templating language that embeds PowerShell code into a text document. It is conceptually 
-and syntactically similar to ERB for Ruby or Twig (see http://twig.sensiolabs.org/) for PHP.
-
-EPS can be used to generate any kind of text. The example below illustrates generating
-plain text, but it could be used to generate HTML in a web application or PowerShell code as
-in the Forge Module generator (see https://github.com/dbroeglin/Forge.Module)
+EPS (Embedded PowerShell), inspired by ERB (see https://en.wikipedia.org/wiki/ERuby), is a templating language that embeds PowerShell code into a text document. It is conceptually and syntactically similar to ERB for Ruby or Twig (see http://twig.sensiolabs.org/) for PHP.
+EPS can be used to generate any kind of text. The example below illustrates generating plain text, but it could be used to generate HTML in a web application or PowerShell code as in the Forge Module generator (see https://github.com/dbroeglin/Forge.Module)
 '@
 
 # Minimum version of the Windows PowerShell engine required by this module

--- a/EPS/Each.ps1
+++ b/EPS/Each.ps1
@@ -1,0 +1,64 @@
+function Each {
+    [CmdletBinding()]
+    Param(
+        [Parameter(ValueFromPipeline=$True, ValueFromPipelinebyPropertyName=$True)]
+        [Object[]]$InputObject,
+
+        [Parameter(Mandatory=$True, Position=0)]
+        [ScriptBlock]$Process,
+
+        [ScriptBlock]$Begin,
+
+        [ScriptBlock]$End,
+
+        [String]$Join
+    )
+    Begin {
+        $StringBuilderVar = New-Object -TypeName 'System.Management.Automation.PSVariable' 'sb'
+        $ItemVar          = New-Object -TypeName 'System.Management.Automation.PSVariable' '_'
+        $IndexVar         = New-Object -TypeName 'System.Management.Automation.PSVariable' @('index', 0)
+        $Vars             = @($ItemVar, $StringBuilderVar, $IndexVar)
+
+        function Invoke-InnerBlock {
+            Param(
+                [ScriptBlock]$ScriptBlock,
+                $Item = $Null
+            )
+            if ($ScriptBlock) {
+                $fsb = New-Object -TypeName 'System.Text.StringBuilder'
+                $StringBuilderVar.Value = $fsb
+                $ItemVar.Value = $Item 
+
+                [void]$ScriptBlock.InvokeWithContext(@{}, $Vars)
+                $fsb.ToString()
+            }
+        }
+        if ($Join) {
+            $Accumulator = New-Object -TypeName 'System.Collections.ArrayList'
+            [void]$Accumulator.Add((Invoke-InnerBlock -ScriptBlock $Begin))
+        } else {
+            [void]$sb.Append((Invoke-InnerBlock -ScriptBlock $Begin))
+        }
+    }
+    Process {
+        if ($Join) {
+            foreach($item in $InputObject) {
+                [void]$Accumulator.Add((Invoke-InnerBlock -ScriptBlock $Process -Item $item))
+                $IndexVar.Value += 1                
+            }
+        } else {
+            foreach($item in $InputObject) {
+                [void]$sb.Append((Invoke-InnerBlock -ScriptBlock $Process -Item $item))
+                $IndexVar.Value += 1                
+            }
+        }
+    }
+    End {
+        if ($Join) {
+            [void]$Accumulator.Add((Invoke-InnerBlock -ScriptBlock $End))
+            [void]$sb.Append($Accumulator.Where({ $_ -ne $Null}) -Join $Join)
+        } else {
+            [void]$sb.Append((Invoke-InnerBlock -ScriptBlock $End))
+        }
+    }
+}

--- a/EPS/Invoke-EpsTemplate.ps1
+++ b/EPS/Invoke-EpsTemplate.ps1
@@ -33,6 +33,7 @@ function Invoke-EpsTemplate {
         try {
             $powershell = [powershell]::Create()
             $powershell.`
+                AddScript((Get-Content "$PSScriptRoot/Each.ps1" -Raw)).`
                 AddScript($block).`
                 AddParameter("Binding", $Binding).`
                 AddParameter("Script", $templateScriptBlock).`

--- a/README.md
+++ b/README.md
@@ -3,33 +3,33 @@
 # EPS
 
 EPS ( *Embedded PowerShell* ), inspired by [ERB][erb], is a templating tool that embeds
-PowerShell code into a text document. It is conceptually and syntactically similar to ERB 
+PowerShell code into a text document. It is conceptually and syntactically similar to ERB
 for Ruby or [Twig][twig] for PHP.
 
 EPS can be used to generate any kind of text. The example below illustrates generating
-plain text, but it could be used to generate HTML as in [DS][ds] or PowerShell code as 
+plain text, but it could be used to generate HTML as in [DS][ds] or PowerShell code as
 in the [Forge Module generator][forge_module].
 
 EPS is available in the [PowerShell Gallary](https://www.powershellgallery.com/packages/EPS).
 You can install the module with the following command:
 
 ```Powershell
-Install-Module -Name EPS 
+Install-Module -Name EPS
 ```
 
 ## Syntax
 
-EPS allows PowerShell code to be embedded within a pair of `<% ... %>`, 
+EPS allows PowerShell code to be embedded within a pair of `<% ... %>`,
 `<%= ... %>`, or `<%# ... %>` as well:
 
 - Code in `<% CODE %>` blocks are executed but no value is inserted.
   - If started with `<%-` : the preceding indentation is trimmed.
-  - If terminated with `-%>` : the following line break is trimmed. 
-- Code in `<%= EXPRESSION %>` blocks insert the value of `EXPRESSION`.   
-  - If terminated with `-%>` : the following line break is trimmed. 
-- Text in `<%# ... %>` blocks are treated as comments and are removed from the output.    
   - If terminated with `-%>` : the following line break is trimmed.
-- `<%%` and `%%>` : are replaced respectively by `<%` and `%>` in the output. 
+- Code in `<%= EXPRESSION %>` blocks insert the value of `EXPRESSION`.
+  - If terminated with `-%>` : the following line break is trimmed.
+- Text in `<%# ... %>` blocks are treated as comments and are removed from the output.
+  - If terminated with `-%>` : the following line break is trimmed.
+- `<%%` and `%%>` : are replaced respectively by `<%` and `%>` in the output.
 
 All blocks accept multi-line content as long as it is valid PowerShell.
 
@@ -37,22 +37,22 @@ All blocks accept multi-line content as long as it is valid PowerShell.
 
 ```PowerShell
 Invoke-EpsTemplate [-Template <string>] [-Binding <hashtable>] [-Safe]  [<CommonParameters>]
-    
-Invoke-EpsTemplate [-Path <string>] [-Binding <hashtable>] [-Safe]  [<CommonParameters>]
-```   
 
-- use `-Template` to render the template in the corresponding string. 
+Invoke-EpsTemplate [-Path <string>] [-Binding <hashtable>] [-Safe]  [<CommonParameters>]
+```
+
+- use `-Template` to render the template in the corresponding string.
 than a file
-- use `-Path` to render the template in the corresponding file.   
-- `-Safe` renders the template in **isolated** mode (in another thread/powershell 
-instance) to avoid variable pollution (variable that are already in the current 
-scope).    
-- if `-Safe` is provided, you must bind your values using `-Binding` option 
-with a `Hashtable` containing key/value pairs.   
+- use `-Path` to render the template in the corresponding file.
+- `-Safe` renders the template in **isolated** mode (in another thread/powershell
+instance) to avoid variable pollution (variable that are already in the current
+scope).
+- if `-Safe` is provided, you must bind your values using `-Binding` option
+with a `Hashtable` containing key/value pairs.
 
 ## Example
 
-In a template file 'Test.eps':   
+In a template file 'Test.eps':
 
 ```
 Hi <%= $name %>
@@ -63,7 +63,7 @@ Please buy me the following items:
   - <%= $_ %> pigs ...
 <% } -%>
 
-Dave is a <% if($True) { %>boy<% } else { %>girl<% } %>. 
+Dave is a <% if($True) { %>boy<% } else { %>girl<% } %>.
 
 Thanks,
 Dave
@@ -80,8 +80,8 @@ Invoke-EpsTemplate -Path Test.eps
 
 Here it is in non-safe mode (render template with values in current run space)
 To use safe mode: using `Invoke-EpsTemplate -Path Test.eps -Safe` with binding values
-   
-It will produce:   
+
+It will produce:
 
 ```
 Hi dave
@@ -109,13 +109,15 @@ which will generate the same output.
 
 ## More examples
 
-You can use multi-line statements in blocks:   
+### Multi-line code or expression blocks
+
+You can use multi-line statements in blocks:
 
 ```powershell
 $template = @'
 <%=
   $name = "dave"
-  
+
   1..5 | %{
     "haha"
   }
@@ -133,6 +135,127 @@ will produce:
 haha haha haha haha haha
 
 Hello, I'm dave.
+```
+
+### Iterating and joining the results
+
+Sometimes we would like to iterate over a collection, generate some text for each
+element and finally join the generated blocks together with a separator.
+
+#### Inside expression blocks
+
+In an expression block we can use the following idiomatic PowerShell snippet:
+
+```powershell
+<%= ("Id", "Name", "Description" | ForEach-Object { "[String]`$$_" }) -Join ",`n" -%>
+```
+which would generate the following result:
+
+```powershell
+[String]$Id,
+[String]$Name,
+[String]$Description
+```
+#### With EPS templating elements
+
+However, due to EPS internal workings, the following code would not work:
+
+```powershell
+<% ("Id", "Name", "Description" | ForEach-Object { -%>
+[String]$<%= $_ -%>
+<% }) -Join ",`n" -%>
+```
+
+The `-Join` operator is ignored by EPS:
+
+```
+[String]$Id[String]$Name[String]$Description
+```
+
+EPS provides an internal `Each` (can only be used for PS v3 and above) function whose
+behavior is similar to `ForEach-Object` but achieves the desired result:
+
+```
+Each [-Process] <scriptblock> [-InputObject <Object[]>] [-Begin <scriptblock>] [-End <scriptblock>] [-Join <string>]
+```
+
+This snippet of EPS would generate the desired result (notice that `-Join` is a parameter of `Each`
+and is not applied to its result value as would be the case with the `-join` operator):
+
+```powershell
+<% "Id", "Name", "Description" | Each { -%>
+[String]$<%= $_ -%>
+<% } -Join ",`n" -%>
+```
+
+and generate:
+
+```powershell
+[String]$Id,
+[String]$Name,
+[String]$Description
+```
+
+In some cases it can be useful to also generate a prefix and suffix to the iterated part:
+
+```powershell
+<% "Id", "Name", "Description" | Each { -%>
+[String]$<%= $_ -%>
+<% } -Begin { %>[NSSession]$Session<% } -End { %>[String]$LogLevel<% } -Join ",`n" -%>
+```
+
+would generate the following result:
+
+```powershell
+[NSSession]$Session,
+[String]$Id,
+[String]$Name,
+[String]$Description,
+[String]$LogLevel
+```
+
+Notice that when using `-Begin` and/or `-End` with `-Join` all blocks are joined together.
+
+If you want to prefix and suffix, _without_ joining the prefix and suffix, use the following
+pattern:
+
+```powershell
+Param(
+<% "Id", "Name", "Description" | Each { -%>
+    [String]$<%= $_ -%>
+<% } -Join ",`n" %>
+)
+```
+
+Which would generate the following result:
+
+```powershell
+Param(
+    [String]$Id,
+    [String]$Name,
+    [String]$Description
+)
+```
+
+### Iterating with an index
+
+In some cases it is useful to iterate over a collection while maintaining an _index_ of the
+current item. The `Each` function exposes a `$index` variable to the script blocks it executes.
+The `$index` variable starts at 0 for the first element.
+
+```powershell
+<% "Dave", "Bob", "Alice" | Each { -%>
+<%= $Index + 1 %>. <%= $_ %>
+<% } -%>
+```
+
+would generate the following listing:
+
+```
+1. Dave
+2. Bob
+3. Alice
+
 ```
 
 ## Contribution

--- a/Tests/Invoke-EpsTemplate.Tests.ps1
+++ b/Tests/Invoke-EpsTemplate.Tests.ps1
@@ -1,5 +1,6 @@
 Set-StrictMode -Version 2
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. "$here\..\EPS\Each.ps1"
 . "$here\..\EPS\New-EpsTemplateScript.ps1"
 . "$here\..\EPS\Invoke-EpsTemplate.ps1"
 
@@ -214,6 +215,17 @@ function EpsTests {
 			{ Invoke-EpsTemplate } | Should Throw "Parameter set cannot be resolved using the specified named parameters"
 		}
 	}
+
+	if ($psversiontable.PSVersion.Major  -ge 3) {
+		Context 'with binding @{ L = @(1, 2, 3) }' {
+			BeforeEach {
+				$Binding  = @{ L = @(1, 2, 3) }
+			}
+			It 'expands "<% $L | Each { %><%= $Index %>. <%= $_ %><% } -Join ":" %>" to "0/1:1/2:2/3"' {
+				Invoke-EpsTemplate -Template '<% $L | Each { %><%= $Index %>/<%= $_ %><% } -Join ":" %>' -Binding $Binding | Should Be "0/1:1/2:2/3"
+			}
+		}
+	}	
 }
 
 Describe 'Invoke-EpsTemplate' {


### PR DESCRIPTION
Due to the internal use of a `StringBuilder` to store generated content, it is not possible to use a syntax like this one to concatenate the results generated by inner parts of a loop:

```powershell
<% ("Id", "Name", "Description" | ForEach-Object { -%>
[String]$<%= $_ -%>
<% }) -Join ",`n" -%>
```
The result of the -Join is ignored from an output point of view as it is not in an expression block.

To work around this limitation this PR introduces the  `Each` function whose behaviour is similar to the `ForEach-Object` function but works with EPS's internal implementation:

```powershell
<% "Id", "Name", "Description" | Each { -%>
[String]$<%= $_ -%>
<% } -Join ",`n" -%>
```
would generate:

```powershell
[String]$Id,
[String]$Name,
[String]$Description
```

At the same time the `Each` function introduces an `$index` variable that is exposed to the script blocks and allows to write:

```powershell
<% "Dave", "Bob", "Alice" | Each { -%>
<%= $Index + 1 %>. <%= $_ %>
<% } -%>
```
to generate:
```
1. Dave
2. Bob
3. Alice
```

The README was extended with exemples of this syntax while, at the same time, showing how EPS can be used to generate PowerShell code.

If you find it acceptable I will publish it as v0.4.0.
