### PR TITLE
Allow relative path to 'Invoke-EpsTemplate -Path'

### DIFF
--- a/EPS/Invoke-EpsTemplate.ps1
+++ b/EPS/Invoke-EpsTemplate.ps1
@@ -16,7 +16,12 @@ function Invoke-EpsTemplate {
     )   
     
     if ($PSCmdlet.ParameterSetName -eq 'File template') {
-        $Template = [IO.File]::ReadAllText($Path)
+        $rootedPath = $Path
+        if (![IO.Path]::isPathRooted($Path)) {
+            $rootedPath = Join-Path (Get-Location) $Path
+        }
+        
+        $Template = [IO.File]::ReadAllText($rootedPath)
     }
 
     $templateScriptBlock = New-EpsTemplateScript -Template $Template


### PR DESCRIPTION
this change let 'Invoke-EpsTemplate -Path' to accept a relative path.

version 0.4.0:

```
PS> git clone https://github.com/straightdave/eps.git
PS> cd eps
PS> Invoke-EpsTemplate -Path .\eps_samples\test.eps
Invoke-EpsTemplate : Exception calling "ReadAllText" with "1" argument(s): 
"Could not find a part of the path 'C:\Users\kimuraw\eps_samples\test.eps'."
```