### PR TITLE
Fix for #25 Confusing description regarding handling of <%%

### DIFF
--- a/EPS/New-EpsTemplateScript.ps1
+++ b/EPS/New-EpsTemplateScript.ps1
@@ -5,7 +5,8 @@ function New-EpsTemplateScript {
         [String]$Template
     )
     $position = 0
-    $Pattern = [regex]"(?sm)<%(?<ind>={1,2}|-|#|%)?(?<code>.*?)(?<tailch>[-=])?%>(?<rspace>[ \t]*\r?\n)?"
+    $Pattern = [regex]("(?sm)(?<lit><%%|%%>)|" + 
+        "<%(?<ind>={1,2}|-|#)?(?<code>.*?)(?<tailch>[-=])?(?<!%)%>(?<rspace>[ \t]*\r?\n)?")
     $StringBuilder = New-Object -TypeName "System.Text.StringBuilder"
 
     function Add-Prolog {
@@ -15,12 +16,9 @@ function New-EpsTemplateScript {
     }
 
     function Add-String {
-        Param([String]$Value, [switch]$NoEscape) 
+        Param([String]$Value) 
 
         if ($Value) {
-            if (!$NoEscape) {
-                $Value = ($Value -replace "<%%", "<%") -replace "%%>", "%>"
-            }
             $Value = $Value -replace '([`"$])', '`$1'
             [void]$StringBuilder.Append(";`$sb.Append(`"").Append($Value).Append("`");")
         }
@@ -59,38 +57,54 @@ function New-EpsTemplateScript {
         $contentLength = $match.Index - $position
         $content       = $Template.Substring($position, $contentLength)
         $position      = $match.Index + $match.Length
-        $ind           = $Match.Groups["ind"].Value
-        $code          = $Match.Groups["code"].Value
-        $tail          = $Match.Groups["tailch"].Value
-        $rspace        = $Match.Groups["rspace"].Value
+        $lit           = $match.Groups["lit"]
 
-        if (($ind -ne '-') -and ($content -ne "")) {
-            Add-String $content
+        if ($lit.Success) {
+            if ($contentLength -ne 0) {
+                Add-String $content
+            }
+            switch ($lit.Value) {
+                "<%%" {
+                    Add-String "<%"
+                }
+                "%%>" {
+                    Add-String "%>"
+                }
+            }
         } else {
-            Add-Code ";"
-        }
-        switch ($ind) {
-            '=' {
-                Add-Expression $code.Trim()
+            $ind           = $match.Groups["ind"].Value
+            $code          = $match.Groups["code"].Value
+            $tail          = $match.Groups["tailch"].Value
+            $rspace        = $match.Groups["rspace"].Value
+
+            if (($ind -ne '-') -and ($contentLength -ne 0)) {
+                Add-String $content
+            } else {
+                Add-Code ";"
             }
-            '-' {
-                Add-String ($content -replace '(?smi)([\n\r]+|\A)[ \t]+\z', '$1')
-                Add-Code $code.Trim()
+            switch ($ind) {
+                '=' {
+                    Add-Expression $code.Trim()
+                }
+                '-' {
+                    Add-String ($content -replace '(?smi)([\n\r]+|\A)[ \t]+\z', '$1')
+                    Add-Code $code.Trim()
+                }
+                '' {
+                    Add-Code $code.Trim()
+                }
+                '%' {
+                    Add-LiteralString "`$sb.Append('<%", $code, ">');"
+                    Add-String $rspace
+                }
+                '#' { # Do nothing
+                }
             }
-            '' {
-                Add-Code $code.Trim()
+            if (($ind -ne '%') -and (($tail -ne '-') -or ($rspace -match '^[^\r\n]'))) {
+                Add-String $rspace
+            } else {
+                Add-Code ";"
             }
-            '%' {
-                Add-LiteralString "`$sb.Append('<%", $code, ">');"
-                Add-String $rspace -NoEscape
-            }
-            '#' {
-            }
-        }
-        if (($ind -ne '%') -and (($tail -ne '-') -or ($rspace -match '^[^\r\n]'))) {
-            Add-String $rspace -NoEscape
-        } else {
-            Add-Code ";"
         }
     }
     if ($position -eq 0) {

--- a/EPS/New-EpsTemplateScript.ps1
+++ b/EPS/New-EpsTemplateScript.ps1
@@ -93,10 +93,6 @@ function New-EpsTemplateScript {
                 '' {
                     Add-Code $code.Trim()
                 }
-                '%' {
-                    Add-LiteralString "`$sb.Append('<%", $code, ">');"
-                    Add-String $rspace
-                }
                 '#' { # Do nothing
                 }
             }

--- a/Tests/Invoke-EpsTemplate.Tests.ps1
+++ b/Tests/Invoke-EpsTemplate.Tests.ps1
@@ -29,7 +29,9 @@ function EpsTests {
 		It '"%%>" expands to "%>"' {
 			Invoke-EpsTemplate -Template "%%>" | Should Be "%>"
 		}
+	}
 
+	Context 'with literal markers' {
 		It '"<%% a %%>" expands to "<% a %>"' {
 			Invoke-EpsTemplate -Template "<%% a %%>" | Should Be "<% a %>"
 		}
@@ -39,7 +41,27 @@ function EpsTests {
 		It '"<%% a %%>`na" expands to "<% a %>`na"' {
 			Invoke-EpsTemplate -Template "<%% a %%>`na" | Should Be "<% a %>`na"
 		}
+		It '"<%% `n %%>" expands to "<% `n %>"' {
+			Invoke-EpsTemplate -Template "<%% `n %%>" | Should Be "<% `n %>"
+		}
+		It '"<%% <%= 1 %> %%>" expands to "<% 1 %>"' {
+			Invoke-EpsTemplate -Template "<%% <%= 1 %> %%>" | Should Be "<% 1 %>"
+		}
+		It '"<%%<%= 1 %> %%>" expands to "<% 1 %>"' {
+			Invoke-EpsTemplate -Template "<%%<%= 1 %> %%>" | Should Be "<%1 %>"
+		}
+		It '"<%% <%= 1 %>%%>" expands to "<% 1 %>"' {
+			Invoke-EpsTemplate -Template "<%% <%= 1 %>%%>" | Should Be "<% 1%>"
+		}
+		It '"<%% <%= 1 -%>`n%%>" expands to "<% 1 %>"' {
+			Invoke-EpsTemplate -Template "<%% <%= 1 -%>`n%%>" | Should Be "<% 1%>"
+		}
+		It '"<%%= <%= 1 %> %%>" expands to "<% 1 %>"' {
+			Invoke-EpsTemplate -Template "<%%= <%= 1 %> %%>" | Should Be "<%= 1 %>"
+		}
+	}
 
+	Context "with comments" {
 		It '"a<%# b %>a" expands to "aa"' {
 			Invoke-EpsTemplate -Template "a<%# b %>a" | Should Be "aa"
 		}
@@ -49,6 +71,12 @@ function EpsTests {
 		It '"a<%# b %> a" expands to "a a"' {
 			Invoke-EpsTemplate -Template "a<%# b %> a" | Should Be "a a"
 		}		
+		It '"a <%# <%% %> a" expands to "a a"' {
+			Invoke-EpsTemplate -Template "a<%# <%% %> a" | Should Be "a a"
+		}
+		It '"a <%# %%> %> a" expands to "a a"' {
+			Invoke-EpsTemplate -Template "a<%# %%> %> a" | Should Be "a a"
+		}
 	}
 
 	Context 'with template "```"`$Test#``0``"' {


### PR DESCRIPTION
Handled the `<%%` and `%%>` cases properly in the regexp. The generation code is now a bit more complex but several edge cases related to literal markers are now handled.