### PR TITLE
Add support for custom helper functions

### DIFF
--- a/EPS/Invoke-EpsTemplate.ps1
+++ b/EPS/Invoke-EpsTemplate.ps1
@@ -11,6 +11,7 @@ function Invoke-EpsTemplate {
 
         [Parameter(ValueFromPipeline=$True, ValueFromPipelinebyPropertyName=$True)]
         [Hashtable]$Binding = @{},
+        [Hashtable]$Helpers = @{},
 
         [switch]$Safe
     )   
@@ -37,9 +38,13 @@ function Invoke-EpsTemplate {
 
         try {
             $powershell = [powershell]::Create()
-            $powershell.`
+                        
+            foreach($h in $helpers.GetEnumerator()) {
+                $powershell = $powershell.AddScript("function $($h.key) { $($h.value) }")
+            }
+            $powershell.`   
                 AddScript("function Each { $function:Each }").`
-                AddScript("function Get-OrElse { ${function:Get-OrElse} }").`
+                AddScript("function Get-OrElse { ${function:Get-OrElse} }").`             
                 AddScript($block).`
                 AddParameter("Binding", $Binding).`
                 AddParameter("Script", $templateScriptBlock).`
@@ -54,7 +59,7 @@ function Invoke-EpsTemplate {
             # InvokeWithContext was introduced in PowerShell version 3.0
             $variablesToDefine = $Binding.GetEnumerator() | 
                 ForEach-Object { New-Object System.Management.Automation.PSVariable @($_.Key, $_.Value) }
-            $templateScriptBlock.InvokeWithContext(@{}, $variablesToDefine)
+            $templateScriptBlock.InvokeWithContext($helpers, $variablesToDefine)
         } else {
             $Binding.GetEnumerator() | ForEach-Object { New-Variable -Name $_.Key -Value $_.Value }
             $templateScriptBlock.Invoke()

--- a/README.md
+++ b/README.md
@@ -311,6 +311,41 @@ Invoke-EpsTemplate -Template @'
 '@
 ```
 
+### Helper functions
+
+If there's a more complicated piece of powershell code that should be reused across multiple files, it can be encapsulated in a helper function, i.e.:
+
+```powershell
+$helpers = @{
+   NumberedList = { 
+     param($arr)
+     $i = 1
+     $arr | foreach-object { "$i. $_"; $i++ } | out-string 
+  }
+}
+```
+
+`$helpers` should be passed to `Invoke-Eps`:
+
+```
+Invoke-EpsTemplate -Path Test.eps -helpers $helpers
+```
+
+Now, `NumberedList` can be used in the template.
+
+```powershell
+<%= NumberedList "Dave", "Bob", "Alice" %>
+```
+
+would generate the following listing:
+
+```
+1. Dave
+2. Bob
+3. Alice
+
+```
+
 ## Contribution
 
 * Original version was written by [Dave Wu](https://github.com/straightdave).

--- a/Tests/Invoke-EpsTemplate.Tests.ps1
+++ b/Tests/Invoke-EpsTemplate.Tests.ps1
@@ -363,6 +363,28 @@ function EpsTests {
 				Invoke-EpsTemplate -Template $Template -Binding $Binding | Should Be $ExpectedResult
 			}
 		}
+
+		Context "with custom helpers" {
+			$helpers = @{
+				Foo = { param($f) return "foo-$f" }
+				Bar = { param($p1, $p2) return "bar-$p1-$p2" }
+				NumberedList = { param($arr)                
+					$arr | foreach-object {$i=1} { "$i. $_"; $i++ } | out-string 
+				  }
+			}
+			It "expands single-arg helper function" {
+				Invoke-EpsTemplate -Template "<%= Foo bar %>" -helpers $helpers | Should Be "foo-bar"
+			}
+			It "expands multi-arg helper function" {
+				Invoke-EpsTemplate -Template "<%= Bar bar1 bar2 %>" -helpers $helpers | Should Be "bar-bar1-bar2"
+			}
+			It "expands array-arg helper function" {
+			Invoke-EpsTemplate -Template '<%= NumberedList "Dave", "Bob", "Alice" %>' -helpers $helpers | Should Be "1. Dave
+2. Bob
+3. Alice
+"
+			}
+		}
 	}	
 }
 


### PR DESCRIPTION
Allows for defining custom powershell functions that can be then invoke in EPS context.

# Example

```powershell
$helpers = @{
   NumberedList = { 
     param($arr)
     $i = 1
     $arr | foreach-object { "$i. $_"; $i++ } | out-string 
  }
}
```

```powershell
Invoke-EpsTemplate -Path Test.eps -helpers $helpers
```

```powershell
<%= NumberedList "Dave", "Bob", "Alice" %>
```

would generate the following listing:

```
1. Dave
2. Bob
3. Alice

```