### PR TITLE
Fix some corner cases and add tests for ThrowForEmptyInsert option

### DIFF
--- a/EPS/Get-OrElse.ps1
+++ b/EPS/Get-OrElse.ps1
@@ -1,11 +1,13 @@
 function Get-OrElse {
     [CmdletBinding()]
     Param(
-        [Parameter(ValueFromPipeline = $True)]
+        [Parameter(ValueFromPipeline = $True,
+        Position=0)]
         [Object]$Value,
 
         [Parameter(Mandatory = $True,
-            ParameterSetName='Default')]
+            ParameterSetName='Default',
+            Position=1)]
         [Object]$Default,
         [Parameter(Mandatory = $True,
             ParameterSetName='Throw')]

--- a/EPS/Invoke-EpsTemplate.ps1
+++ b/EPS/Invoke-EpsTemplate.ps1
@@ -34,7 +34,11 @@ function Invoke-EpsTemplate {
             Param([ScriptBlock]$Script, [Hashtable]$Binding)
 
             $Binding.GetEnumerator() | ForEach-Object { New-Variable -Name $_.Key -Value $_.Value }
-            $Script.Invoke()
+            try {
+                $Script.Invoke()
+            } catch {
+                throw $_
+            }
         }
 
         try {

--- a/EPS/New-EpsTemplateScript.ps1
+++ b/EPS/New-EpsTemplateScript.ps1
@@ -35,16 +35,15 @@ function New-EpsTemplateScript {
 
     function Add-Expression {
         Param([String]$Value)
-        [string]$CloseExpression = ""
-        if($ThrowForEmptyInsert) {
-            $CloseExpression += " | Get-OrElse -Throw"
-        }
-        $CloseExpression += ")`");"
+
+        $Value = if ($ThrowForEmptyInsert) {
+           '$(' + $Value + ') | Get-OrElse -Throw'
+        } else {$Value}
 
         [void]$StringBuilder.`
             Append("`$sb.Append(`"`$(").`
             Append($Value.Replace('""', '`"`"')).`
-            Append($CloseExpression) 
+            Append(")`");")
     }
 
     function Add-Code {

--- a/Tests/Get-OrElse.Tests.ps1
+++ b/Tests/Get-OrElse.Tests.ps1
@@ -15,7 +15,6 @@ Describe 'Get-OrElse' {
             Get-OrElse 1   "default" | Should Be 1
             Get-OrElse " " "default" | Should Be " "
         }
-
     }
     Context 'with pipeline value' {
         It 'returns default if value is null' {
@@ -28,6 +27,18 @@ Describe 'Get-OrElse' {
             "a" | Get-OrElse -Default "default" | Should Be "a"
             1   | Get-OrElse -Default "default" | Should Be 1
             " " | Get-OrElse -Default "default" | Should Be " "
+        }
+    }
+    Context 'with throw option' {
+        It 'throws an error if the input is null' {
+            {$Null | Get-OrElse -Throw} | Should -Throw
+        }
+        It 'does not throw an error if the input is not null' {
+            {"default" | Get-OrElse -Throw} | Should -Not -Throw
+            {$False | Get-OrElse -Throw} | Should -Not -Throw
+        }
+        It 'returns the correct value' {
+            "default" | Get-OrElse -Throw | Should Be "default"
         }
     }
 }

--- a/Tests/Invoke-EpsTemplate.Tests.ps1
+++ b/Tests/Invoke-EpsTemplate.Tests.ps1
@@ -396,6 +396,21 @@ function EpsTests {
 				Invoke-EpsTemplate -Template '<%= NumberedList "Dave", "Bob", "Alice" %>' -helpers $helpers | Should Be ("1. Dave", "2. Bob", "3. Alice" | Out-String)
 			}
 		}
+        Context "with ThrowForEmptyInsert" {
+            It "throws when an insert expression evaluates to empty" {
+                {Invoke-EpsTemplate -Template '<%= $null %>' -ThrowForEmptyInsert} | Should -Throw
+                {Invoke-EpsTemplate -Template '<%= "" %>' -ThrowForEmptyInsert} | Should -Throw
+                {Invoke-EpsTemplate -Template '<%=%>' -ThrowForEmptyInsert} | Should -Throw
+            }
+            It "does not throw when expression is not being inserted" {
+                {Invoke-EpsTemplate -Template '<% $null %>' -ThrowForEmptyInsert} | Should -Not -Throw
+                {Invoke-EpsTemplate -Template '<% "" %>' -ThrowForEmptyInsert} | Should -Not -Throw
+                {Invoke-EpsTemplate -Template '<%%>' -ThrowForEmptyInsert} | Should -Not -Throw
+            }
+            It "Evaluates to the correct value" {
+                Invoke-EpsTemplate -Template '<%= "something" %>' -ThrowForEmptyInsert | Should Be "something"
+            }
+        }
 }	
 }
 

--- a/Tests/Invoke-EpsTemplate.Tests.ps1
+++ b/Tests/Invoke-EpsTemplate.Tests.ps1
@@ -407,9 +407,18 @@ function EpsTests {
                 {Invoke-EpsTemplate -Template '<% "" %>' -ThrowForEmptyInsert} | Should -Not -Throw
                 {Invoke-EpsTemplate -Template '<%%>' -ThrowForEmptyInsert} | Should -Not -Throw
             }
-            It "Evaluates to the correct value" {
+            It "evaluates to the correct value" {
                 Invoke-EpsTemplate -Template '<%= "something" %>' -ThrowForEmptyInsert | Should Be "something"
             }
+            It "does not throw for if statements" {
+               {Invoke-EpsTemplate -Template '<%= if ($true) {"true"} else {"false"} %>' -ThrowForEmptyInsert} | Should -Not -Throw
+               {Invoke-EpsTemplate -Template '<%= if ($true) {"true"} else {$null} %>' -ThrowForEmptyInsert} | Should -Not -Throw
+               {Invoke-EpsTemplate -Template '<%= if ($null) {$null} else {"false"} %>' -ThrowForEmptyInsert} | Should -Not -Throw
+            }
+            It "does throw for if statements that evaluate to empty" {
+               {Invoke-EpsTemplate -Template '<%= if ($true) {$null} else {$null} %>' -ThrowForEmptyInsert} | Should -Throw
+               {Invoke-EpsTemplate -Template '<%= if ($true) {""} else {""} %>' -ThrowForEmptyInsert} | Should -Throw
+               {Invoke-EpsTemplate -Template '<%= if ($null) {""} else {""} %>' -ThrowForEmptyInsert} | Should -Throw            }
         }
 }	
 }


### PR DESCRIPTION
This pull request fixes a few things that worked slightly differently than expected for ThrowForEmptyInsert.

 - Get-OrElse works with positional parameters again, in addition to the pipeline as shown in the documentation.
 - ThrowForEmptyInsert works properly with safe mode.
 - Adds tests.